### PR TITLE
start porting machsuite benchmarks

### DIFF
--- a/machsuite/aes.skip
+++ b/machsuite/aes.skip
@@ -1,0 +1,314 @@
+// Subroutines if not tables for sbox
+//def gf_alog (x: ubit<8>) {
+//  let atb: ubit<8> = 1;
+//  let i: bit<32> = 0;
+//  while (atb != x) {
+//    let z = atb;
+//    atb := atb << 1;
+//    if (z & 128) {
+//      atb := atb ^ 27 ^ z;
+//    }
+//    i := i + 1;
+//  }
+//  atb := 1;
+//  let j: bit<32> = 0;
+//  while (j < (255 - i)) {
+//    let z = atb;
+//    atb := atb << 1;
+//    if (z & 128) {
+//      atb := atb ^ 27 ^ z;
+//    }
+//    j := j + 1;
+//  }
+//  let return = atb;
+//}
+//
+//def rj_sbox (x: ubit<8>) {
+//  if (x != 0) {
+//    x := gf_alog(x);
+//  }
+//  let sb = x;
+//  let y = x;
+//  y := (y<<1)|(y>>7);
+//  sb := sb ^ y;
+//  y := (y<<1)|(y>>7);
+//  sb :=  sb ^ y;
+//  y := (y<<1)|(y>>7);
+//  sb := sb ^ y;
+//  y := (y<<1)|(y>>7);
+//  sb :=  sb ^ y;
+//  let return =  sb ^ 99;
+//}
+
+def rj_xtime (x: ubit<8>): ubit<8> = {
+  if ((x & 128) != 0) {
+    return (x << 1) ^ 27;
+  } else {
+    return x << 1;
+  }
+}
+
+def aes_subBytes (buf: ubit<8>[16], sbox: ubit<8>[256]) = {
+  for (let i = 0..16) {
+    let read = buf[i];
+    ---
+    //buf[i] := rj_sbox(read);
+    buf[i] := sbox[read];
+  }
+}
+
+def aes_addRoundKey (buf: ubit<8>[16], key: ubit<8>[32], offset: ubit<1>) {
+  for (let i = 0..16) {
+    let read = buf[i];
+    ---
+    if (offset == 0) {
+      buf[i] := read ^ key[i];
+    } else {
+      buf[i] := read ^ key[i + 16];
+    }
+  }
+}
+
+def aes_addRoundKey_cpy (buf: ubit<8>[16], key: ubit<8>[32], cpk: ubit<8>[32]) {
+  for (let i = 0..16) {
+    let read = buf[i];
+    let _key = key[i];
+    cpk[i] := _key;
+    ---
+    buf[i] := read ^ _key;
+    cpk[16 + i] := key[16 + i];
+  }
+}
+
+def aes_shiftRows (buf: ubit<8>[16]) {
+  let temp = buf[1];
+  ---
+  let read = buf[5];
+  ---
+  buf[1] := read;
+  ---
+  read := buf[9];
+  ---
+  buf[5] := read;
+  ---
+  read := buf[13];
+  ---
+  buf[9] := read;
+  ---
+  buf[13] := temp;
+  ---
+  temp := buf[10];
+  ---
+  read := buf[2];
+  ---
+  buf[10] := read;
+  ---
+  buf[2] := temp;
+  ---
+  temp := buf[3];
+  ---
+  read := buf[15];
+  ---
+  buf[3] := read;
+  ---
+  read := buf[11];
+  ---
+  buf[15] := read;
+  ---
+  read := buf[7];
+  ---
+  buf[11] := read;
+  ---
+  buf[7] := temp;
+  ---
+  temp := buf[14];
+  ---
+  read := buf[6];
+  ---
+  buf[14] := read;
+  ---
+  buf[6] := temp;
+}
+
+def aes_mixColumns (buf: ubit<8>[16]) {
+  // NOTE(rachit): Perfect place for unrolling and combine blocks.
+  for (let i = 0..4) {
+    let a = buf[4 * i];
+    ---
+    let b = buf[4 * i + 1];
+    ---
+    let c = buf[4 * i + 2];
+    ---
+    let d = buf[4 * i + 3];
+    ---
+    let e: ubit<8> = a ^ b ^ c ^ d;
+    ---
+    let temp: ubit<8> = rj_xtime(a ^ b);
+    buf[4 * i] := a ^ e ^ temp;
+    ---
+    temp := rj_xtime(b ^ c);
+    buf[4 * i + 1] := b ^ e ^ temp;
+    ---
+    temp := rj_xtime(c ^ d);
+    buf[4 * i + 2] := c ^ e ^ temp;
+    ---
+    temp := rj_xtime(d ^ a);
+    buf[4 * i + 3] := d ^ e ^ temp;
+  }
+}
+
+def aes_expandEncKey (k: ubit<8>[32], rc: ubit<8>, sbox: ubit<8>[256]) = {
+  let _k = k[0];
+  ---
+  //let _rj = rj_sbox(k[29]) ^ rc;
+  let _rj = sbox[k[29]] ^ rc;
+  ---
+  k[0] := _k ^ _rj;
+  ---
+  _k := k[1];
+  ---
+  //_rj := rj_sbox(k[30]);
+  _rj := sbox[k[30]];
+  ---
+  k[1] := _k ^ _rj;
+  ---
+  _k := k[2];
+  ---
+  //_rj := rj_sbox(k[31]);
+  _rj := sbox[k[31]];
+  ---
+  k[2] := _k ^ _rj;
+  ---
+  _k := k[3];
+  ---
+  //_rj := rj_sbox(k[28]);
+  _rj := sbox[k[28]];
+  ---
+  k[3] := _k ^ _rj;
+  ---
+  for (let i = 4..16) {
+    _k := k[i];
+    ---
+    _rj := k[i-4];
+    ---
+    k[i] := _k ^ _rj;
+  }
+  ---
+  _k := k[16];
+  ---
+  //let _rj = rj_sbox(k[12]);
+  _rj := sbox[k[12]];
+  ---
+  k[16] := _k ^ _rj;
+  ---
+  _k := k[17];
+  ---
+  //_rj := rj_sbox(k[13]);
+  _rj := sbox[k[13]];
+  ---
+  k[17] := _k ^ _rj;
+  ---
+  _k := k[18];
+  ---
+  //_rj := rj_sbox(k[14]);
+  _rj := sbox[k[14]];
+  ---
+  k[18] := _k ^ _rj;
+  ---
+  _k := k[19];
+  ---
+  //_rj := rj_sbox(k[15]);
+  _rj := sbox[k[15]];
+  ---
+  k[19] := _k ^ _rj;
+  ---
+  for (let i = 20..32) {
+    _k := k[i];
+    ---
+    _rj := k[i-4];
+    ---
+    k[i] := _k ^ _rj;
+  }
+}
+
+decl key:ubit<8>[32];
+decl enckey:ubit<8>[32];
+decl deckey:ubit<8>[32];
+decl k:ubit<8>[32];
+decl buf:ubit<8>[16];
+
+let sbox: ubit<8>[256] = {
+    0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5,
+    0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+    0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0,
+    0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+    0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc,
+    0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+    0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a,
+    0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+    0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0,
+    0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+    0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b,
+    0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+    0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85,
+    0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+    0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5,
+    0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+    0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17,
+    0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+    0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88,
+    0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+    0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c,
+    0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+    0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9,
+    0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+    0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6,
+    0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+    0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e,
+    0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+    0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94,
+    0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+    0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68,
+    0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16
+};
+{
+  // INIT
+  let rcon: ubit<8> = 1;
+
+  for (let i = 0..32) {
+    enckey[i] := k[i];
+    deckey[i] := k[i];
+  }
+  ---
+  for (let i = 0..7) {
+    aes_expandEncKey(deckey, rcon, sbox);
+    rcon := (rcon<<1) ^ (((rcon>>7) & 1) * 27);
+  }
+  aes_addRoundKey_cpy(buf, enckey, key);
+  ---
+  rcon := 1;
+  for (let i = 1..14) {
+    aes_subBytes(buf, sbox);
+    ---
+    aes_shiftRows(buf);
+    ---
+    aes_mixColumns(buf);
+    ---
+    if ((i & 1) != 0) {
+      aes_addRoundKey(buf, key, 1);
+    } else {
+      aes_expandEncKey(key, rcon, sbox);
+      rcon := (rcon<<1) ^ (((rcon>>7) & 1) * 27);
+      ---
+      aes_addRoundKey(buf, key, 0);
+    }
+  }
+  ---
+  aes_subBytes(buf, sbox);
+  ---
+  aes_shiftRows(buf);
+  ---
+  aes_expandEncKey(key, rcon, sbox);
+  ---
+  aes_addRoundKey(buf, key, 0);
+}

--- a/machsuite/bfs-bulk.fuse
+++ b/machsuite/bfs-bulk.fuse
@@ -1,0 +1,55 @@
+// record edge_t {
+//   src: ubit<64>;
+//   dst: ubit<64>
+// }
+
+// record node_t {
+//   edge_begin: ubit<64>;
+//   edge_end: ubit<64>
+// }
+
+decl nodes_edge_begin: ubit<64>[256];
+decl nodes_edge_end: ubit<64>[256];
+decl edges_src: ubit<64>[4096];
+decl edges_dst: ubit<64>[4096];
+
+decl starting_node: ubit<64>;
+decl level: bit<8>[256];
+decl level_counts: ubit<64>[10];
+
+let MAX_LEVEL: bit<8> = 127;
+
+level[starting_node] := 0;
+level_counts[0] := 1;
+---
+
+for (let horizon: bit<8> = 0..10) {
+  decor "#pragma HLS loop_tripcount max=10 min=1"
+  let cnt: ubit<64> = 0;
+  for (let n: ubit<8> = 0..256) {
+    let tmp_l = level[n];
+    ---
+    if (tmp_l == horizon) {
+      let e = nodes_edge_begin[n];
+      ---
+      let tmp_end = nodes_edge_end[n];
+      ---
+      while (e < tmp_end) {
+        decor "#pragma HLS loop_tripcount avg=17"
+        let tmp_dst = edges_dst[e];
+        let tmp_level = level[tmp_dst];
+        ---
+        if (tmp_level == MAX_LEVEL) {
+          level[tmp_dst] := horizon + 1;
+          ---
+          cnt := cnt + 1;
+        }
+        e := e + 1;
+      }
+    }
+  }
+  level_counts[horizon + 1] := cnt;
+  if (cnt == 0) {
+    horizon := 10;
+  }
+}

--- a/machsuite/bfs-queue.fuse
+++ b/machsuite/bfs-queue.fuse
@@ -1,0 +1,87 @@
+// record edge_t {
+//   src: ubit<64>;
+//   dst: ubit<64>
+// }
+
+// record node_t {
+//   edge_begin: ubit<64>;
+//   edge_end: ubit<64>
+// }
+
+// decor "#pragma SDS data copy(nodes[0:256])"
+// decor "#pragma SDS data zero_copy(level[0:256])"
+// decor "#pragma SDS data zero_copy(level_counts[0:10])"
+
+decl nodes_edge_begin: ubit<64>[256];
+decl nodes_edge_end: ubit<64>[256];
+decl edges_src: ubit<64>[4096];
+decl edges_dst: ubit<64>[4096];
+
+decl starting_node_fake: ubit<64>;
+decl level: bit<8>[256];
+decl level_counts: ubit<64>[10];
+
+let queue: ubit<64>[256];
+let MAX_LEVEL: bit<8> = 127;
+let starting_node: ubit<64> = 38;
+
+{
+  let q_in: ubit<64> = 1;
+  let q_out: ubit<64> = 0;
+  level[starting_node] := 0;
+  level_counts[0] := 1;
+
+  if (q_in == 0) {
+    queue[255] := starting_node;
+  } else {
+    queue[q_in - 1] := starting_node;
+  }
+  let temp_q_in = (q_in + 1) % 256;
+  q_in := temp_q_in;
+  ---
+
+  for (let dummy: ubit<8> = 0..256) {
+    decor "#pragma HLS loop_tripcount max=256 min=1"
+    let q_empty = false;
+    if (q_in > q_out) {
+      q_empty := (q_in == q_out + 1);
+    } else {
+      q_empty := (q_in == 0) && (q_out == 255);
+    }
+
+    if (q_empty) {
+      dummy := (256 as ubit<8>);
+    }
+
+    let n = queue[q_out];
+    q_out := (q_out + 1) % 256;
+    let e = nodes_edge_begin[n];
+    let tmp_end: ubit<64> = nodes_edge_end[n];
+    ---
+
+    while(e < tmp_end) {
+      decor "#pragma HLS loop_tripcount avg=17"
+      let tmp_dst: ubit<64> = edges_dst[e];
+      let tmp_level: bit<8> = level[tmp_dst];
+      ---
+
+      if (tmp_level == MAX_LEVEL) {
+        tmp_level := level[n] + 1;
+        let tmp_level_counts = level_counts[tmp_level];
+        ---
+
+        level[tmp_dst] := tmp_level;
+        level_counts[tmp_level] := tmp_level_counts + 1;
+
+        if (q_in == 0) {
+          queue[255] := tmp_dst;
+        } else {
+          queue[q_in - 1] := tmp_dst;
+        }
+        temp_q_in := (q_in + 1) % 256;
+        q_in := temp_q_in;
+      }
+      e := e + 1;
+    }
+  }
+}

--- a/machsuite/check.sh
+++ b/machsuite/check.sh
@@ -1,0 +1,11 @@
+#!/bin/zsh
+
+echo 'A non-zero number after the filename indicates that it cannot be compiled'
+
+for file in *.fuse; do
+ fud e --to futil $file >/dev/null 2>&1
+echo $file : $?
+done
+
+echo 'Following files are skipped'
+echo *.skip

--- a/machsuite/fft-strided.fuse
+++ b/machsuite/fft-strided.fuse
@@ -1,0 +1,43 @@
+decl real: fix<64,32>[1024];
+decl img: fix<64,32>[1024];
+decl real_twid: fix<64,32>[512];
+decl img_twid: fix<64,32>[513];
+
+let span:bit<32> = 1024 >> 1;
+let log:bit<32> = 0;
+
+while (span != 0) {
+  let odd = span;
+  while (odd < 1024) {
+    // based on baseline software, but check for rewrites
+    decor "#pragma HLS loop_tripcount avg=512"
+    odd := odd | span;
+    let even = odd ^ span;
+    let real_odd = real[odd];
+    let img_odd = img[odd];
+    ---
+    let real_even = real[even];
+    let img_even = img[even];
+    let temp_r = real_even + real_odd;
+    let temp_i = img_even + img_odd;
+    ---
+    real[odd] := real_even - real_odd;
+    img[odd] := img_even - img_odd;
+    ---
+    real[even] := temp_r;
+    img[even] := temp_i;
+    let rootindex = (((even << log) as ubit<10>) & (1023 as ubit<10>));
+    ---
+    if (rootindex != 0) {
+      let temp = real_twid[rootindex] * real[odd] - img_twid[rootindex] * img[odd];
+      img_odd := img[odd];
+      ---
+      img[odd] := real_twid[rootindex] * img_odd + img_twid[rootindex] * real[odd];
+      ---
+      real[odd] := temp;
+    }
+    odd := odd + 1;
+  }
+  span := span >> 1;
+  log := log + 1;
+}

--- a/machsuite/gemm-blocked.fuse
+++ b/machsuite/gemm-blocked.fuse
@@ -1,0 +1,24 @@
+decl m1: fix<64, 32>[64][64];
+decl m2: fix<64, 32>[64][64];
+decl prod: fix<64, 32>[64][64];
+
+for (let i: ubit<6> = 0..64) {
+  for (let j: ubit<6>  = 0..64) {
+    prod[i][j] := (0.0 as fix<64, 32>);
+  }
+}
+---
+for (let jj: ubit<4> = 0..8) {
+  for (let kk: ubit<4> = 0..8) {
+    for (let i: ubit<6> = 0..64) {
+      for (let j: ubit<4> = 0..8) {
+        for (let k: ubit<4> = 0..8) {
+          let temp_x = m1[i][kk * 8 + k];
+          let mul = temp_x * m2[kk * 8 + k][jj * 8 + j];
+        } combine {
+          prod[i][jj * 8 + j] += mul;
+        }
+      }
+    }
+  }
+}

--- a/machsuite/gemm-ncubed.fuse
+++ b/machsuite/gemm-ncubed.fuse
@@ -1,0 +1,15 @@
+decl m1: fix<64, 32>[64 bank 2][64 bank 4];
+decl m2: fix<64, 32>[64 bank 8][64 bank 4];
+decl prod: fix<64, 32>[64 bank 2][64 bank 4];
+
+for (let i: ubit<6> = 0..64) {
+  for (let j: ubit<6> = 0..64) {
+    let sum: fix<64, 32> = 0.0;
+    for (let k: ubit<6> = 0..64) {
+      let mult = m1[i][k] * m2[k][j];
+    } combine {
+      sum += mult;
+    }
+    prod[i][j] := sum;
+  }
+}

--- a/machsuite/kmp.fuse
+++ b/machsuite/kmp.fuse
@@ -1,0 +1,51 @@
+def cpf(pattern: bit<8>[4], kmpNext: bit<32>[4]) = {
+  let k: bit<32> = 0;
+  kmpNext[0] := 0;
+  ---
+  for (let q: ubit<2> = 1..4) {
+    decor "#pragma HLS loop_tripcount max=4 min=0"
+    let k_val = pattern[k];
+    ---
+    let q_val = pattern[q];
+    ---
+    while (k > 0 && k_val != q_val) {
+      decor "#pragma HLS loop_tripcount max=0 min=0"
+      k := kmpNext[q];
+      k_val := pattern[k];
+      ---
+      q_val := pattern[q];
+    }
+    ---
+    if (k_val == q_val) {
+      k := k + 1;
+    }
+    kmpNext[q] := k;
+  }
+}
+
+decl pattern: bit<8>[4];
+decl input: bit<8>[32411];
+decl kmpNext: bit<32>[4];
+decl n_matches: bit<32>[1];
+
+n_matches[0] := 0;
+cpf(pattern, kmpNext);
+---
+let q:bit<32> = 0;
+for (let i: ubit<15> = 0..32411) {
+  decor "#pragma HLS loop_tripcount max=32411 min=0"
+  while (q > 0 && pattern[q] != input[i]) {
+    decor "#pragma HLS loop_tripcount max=1 min=0"
+    q := kmpNext[q];
+  }
+  ---
+  if (pattern[q] == input[i]) {
+    q := q + 1;
+  }
+  if (q >= 4) {
+    let temp:bit<32> = n_matches[0];
+    ---
+    n_matches[0] := temp + 1;
+    q := kmpNext[q - 1];
+  }
+}

--- a/machsuite/md-grid.skip
+++ b/machsuite/md-grid.skip
@@ -1,0 +1,132 @@
+record ivector_t {
+  x: bit<32>;
+  y: bit<32>;
+  z: bit<32>
+}
+
+record dvector_t {
+  x: double;
+  y: double;
+  z: double
+}
+
+decor "#pragma SDS data copy(n_points[0:64])"
+
+decl n_points: bit<32>[4][4][4];
+decl force_x: double[4][4][4][10];
+decl force_y: double[4][4][4][10];
+decl force_z: double[4][4][4][10];
+decl position_x: double[4][4][4][10];
+decl position_y: double[4][4][4][10];
+decl position_z: double[4][4][4][10];
+
+let force_local: dvector_t[4][4][4][10];
+let empty: dvector_t = {x = 0.0; y = 0.0; z = 0.0};
+
+{
+  for(let b0x = 0..4){
+    for(let b0y = 0..4){
+      for(let b0z = 0..4){
+        for(let p_idx = 0..10){
+          force_local[b0x][b0y][b0z][p_idx] := empty;
+        }
+      }
+    }
+  }
+  ---
+  for(let b0x = 0..4){
+    for(let b0y = 0..4){
+      for(let b0z = 0..4){
+        let b1min: ivector_t = {x = 0; y = 0; z = 0};
+        let b1max: ivector_t = {x = 4; y = 4; z = 4};
+        if((b0x - 1) > b1min.x){
+          let newbmin : ivector_t = {x = b0x - 1; y = b1min.y; z = b1min.z};
+          b1min := newbmin;
+        }
+        if((b0y - 1) > b1min.y){
+          let newbmin : ivector_t = {x = b1min.x; y = b0y - 1; z = b1min.z};
+          b1min := newbmin;
+        }
+        if((b0z - 1) > b1min.z){
+          let newbmin : ivector_t = {x = b1min.x; y = b1min.y; z = b0z -1};
+          b1min := newbmin;
+        }
+        if((b0x + 2) < b1max.x){
+          let newbmax : ivector_t = {x = b0x + 2; y = b1max.y; z = b1max.z};
+          b1max := newbmax;
+        }
+        if((b0y + 2) < b1max.y){
+          let newbmax : ivector_t = {x = b1max.x; y = b0y + 2; z = b1max.z};
+          b1max := newbmax;
+        }
+        if((b0z + 2) < b1max.z){
+          let newbmax : ivector_t = {x = b1max.x; y = b1max.y; z = b0z + 2};
+          b1max := newbmax;
+        }
+        ---
+        let b1x:bit<32> = b1min.x;
+        while(b1x < b1max.x){
+          decor "#pragma HLS loop_tripcount max=2 min=0"
+          let b1y:bit<32> = b1min.y;
+          while(b1y < b1max.y){
+            decor "#pragma HLS loop_tripcount max=2 min=0"
+            let b1z:bit<32> = b1min.z;
+            while(b1z < b1max.z){
+              decor "#pragma HLS loop_tripcount max=2 min=0"
+              //let base_q = position[b1x][b1y][b1z][0].x;
+              let q_idx_range = n_points[b1x][b1y][b1z];
+              ---
+              let p_idx:bit<32> = 0;
+              let p_idx_upper = n_points[b0x][b0y][b0z];
+              while(p_idx < p_idx_upper){
+                decor "#pragma HLS loop_tripcount avg=3"
+                let p: dvector_t = {x = position_x[b0x][b0y][b0z][p_idx]; y = position_y[b0x][b0y][b0z][p_idx]; z = position_z[b0x][b0y][b0z][p_idx]};
+                ---
+                let sum_x = force_local[b0x][b0y][b0z][p_idx].x;
+                let sum_y = force_local[b0x][b0y][b0z][p_idx].y;
+                let sum_z = force_local[b0x][b0y][b0z][p_idx].z;
+                let q_idx:bit<32> = 0;
+                while(q_idx < q_idx_range){
+                  decor "#pragma HLS loop_tripcount avg=3"
+                  let q: dvector_t = {x = position_x[b1x][b1y][b1z][q_idx]; y = position_y[b1x][b1y][b1z][q_idx]; z = position_z[b1x][b1y][b1z][q_idx]};
+                  if ((q.x != p.x) || (q.y != p.y) || (q.z != p.z)){
+                    // Compute the LJ-potential
+                    let dx = p.x - q.x;
+                    let dy = p.y - q.y;
+                    let dz = p.z - q.z;
+                    let r2inv = 1.0 / (dx*dx + dy*dy + dz*dz);
+                    let r6inv = r2inv*r2inv*r2inv;
+                    let potential = r6inv*(1.5*r6inv - 2.0);
+                    // Update forces
+                    let f = r2inv*potential;
+                    sum_x := sum_x + (f*dx);
+                    sum_y := sum_y + (f*dy);
+                    sum_z := sum_z + (f*dz);
+                  }
+                  q_idx := q_idx + 1;
+                } // loop_q
+                ---
+                let newforcelocal : dvector_t = {x = sum_x; y = sum_y; z = sum_z};
+                force_local[b0x][b0y][b0z][p_idx] := newforcelocal;
+                p_idx := p_idx + 1;
+              } // loop_p
+              b1z := b1z + 1;
+            }
+            b1y := b1y + 1;
+          }
+          b1x := b1x + 1;
+        } // loop_grid1_*
+  }}} // loop_grid0_*
+  ---
+  for(let b0x = 0..4){
+    for(let b0y = 0..4){
+      for(let b0z = 0..4){
+        for(let p_idx = 0..10){
+          force_x[b0x][b0y][b0z][p_idx] := force_local[b0x][b0y][b0z][p_idx].x;
+          force_y[b0x][b0y][b0z][p_idx] := force_local[b0x][b0y][b0z][p_idx].y;
+          force_z[b0x][b0y][b0z][p_idx] := force_local[b0x][b0y][b0z][p_idx].z;
+        }
+      }
+    }
+  }
+}

--- a/machsuite/md-knn.fuse
+++ b/machsuite/md-knn.fuse
@@ -1,0 +1,47 @@
+decl force_x: fix<64,32>[256];
+decl force_y: fix<64,32>[256];
+decl force_z: fix<64,32>[256];
+decl position_x: fix<64,32>[256];
+decl position_y: fix<64,32>[256];
+decl position_z: fix<64,32>[256];
+decl nl: bit<32>[256][16];
+
+let lj1:fix<64,32> = 1.5;
+let lj2:fix<64,32> = 2.0;
+
+for (let i: ubit<8> = 0..256) {
+  let ix = position_x[i];
+  let iy = position_y[i];
+  let iz = position_z[i];
+  ---
+
+  let fx: fix<64,32> = 0.0;
+  let fy: fix<64,32> = 0.0;
+  let fz: fix<64,32> = 0.0;
+
+  for (let j: ubit<4> = 0..16) {
+    let j_idx = nl[i][j];
+
+    let jx = position_x[j_idx];
+    let jy = position_y[j_idx];
+    let jz = position_z[j_idx];
+
+    let delx = ix - jx;
+    let dely = iy - jy;
+    let delz = iz - jz;
+
+    let r2inv = (1.0 as fix<64, 32>) / (delx * delx + dely * dely + delz * delz);
+    let r6inv = r2inv * r2inv * r2inv;
+    let potential = r6inv * (lj1 * r6inv - lj2);
+
+    let force = r2inv * potential;
+  } combine {
+    fx += delx * force;
+    fy += dely * force;
+    fz += delz * force;
+  }
+
+  force_x[i] := fx;
+  force_y[i] := fy;
+  force_z[i] := fz;
+}

--- a/machsuite/nw.fuse
+++ b/machsuite/nw.fuse
@@ -1,0 +1,117 @@
+// ALEN: 128
+// BLEN: 128
+
+decl SEQA: bit<8>[128];
+decl SEQB: bit<8>[128];
+decl alignedA: bit<8>[256];
+decl alignedB: bit<8>[256];
+decl M: bit<32>[16641];
+decl ptr: bit<8>[16641];
+
+let MATCH_SCORE:bit<32>    = 1;
+let MISMATCH_SCORE:bit<32> = 0-1; // -1
+let GAP_SCORE:bit<32>      = 0-1; // -1
+let ALIGN:bit<8>      = 92; // ASCII for '\\'
+let SKIPA:bit<8>      = 94; // ASCII for '^'
+let SKIPB:bit<8>      = 60; // ASCII for '<'
+let DASH:bit<8>       = 45; // ASCII for '-'
+let UNDERSCORE:bit<8> = 95; // ASCII for '_'
+
+for (let a_idx: bit<32> = 0..129) {
+  decor "#pragma HLS loop_tripcount max=128 min=0"
+  M[a_idx] := a_idx * GAP_SCORE;
+}
+
+---
+
+for (let b_idx: bit<32> = 0..129) {
+  decor "#pragma HLS loop_tripcount max=128 min=0"
+  M[b_idx*129] := b_idx * GAP_SCORE;
+}
+
+---
+
+for (let b_idx: bit<32> = 1..129) {
+  decor "#pragma HLS loop_tripcount max=128 min=0"
+  for (let a_idx: bit<32> = 1..129) {
+    decor "#pragma HLS loop_tripcount max=128 min=0"
+    let score:bit<32>   = 0;
+    if (SEQA[a_idx-1] == SEQB[b_idx-1]) {
+      score := MATCH_SCORE;
+    } else {
+      score := MISMATCH_SCORE;
+    }
+
+    let row_up:bit<32> = (b_idx-1) * 129;
+    let row:bit<32>    = (b_idx) * 129;
+
+    let up_left:bit<32> = M[row_up + a_idx-1] + score;
+    ---
+    let up:bit<32>      = M[row_up + a_idx  ] + GAP_SCORE;
+    ---
+    let left:bit<32>    = M[row    + a_idx-1] + GAP_SCORE;
+
+    let max:bit<32>     = 0;
+    if (up_left >= up && up_left >= left) {
+      max := up_left;
+    } else {
+      if (up >= left) {
+        max := up;
+      } else {
+        max := left;
+      }
+    }
+    ---
+    M[row + a_idx] := max;
+    if (max == left) {
+      ptr[row + a_idx] := SKIPB;
+    } else {
+      if (max == up) {
+        ptr[row + a_idx] := SKIPA;
+      } else {
+        ptr[row + a_idx] := ALIGN;
+      }
+    }
+  }
+}
+---
+let a_idx:bit<32> = 128; // ALEN
+let b_idx:bit<32> = 128; // BLEN
+let a_str_idx:bit<32> = 0;
+let b_str_idx:bit<32> = 0;
+
+while (a_idx>0 || b_idx>0) {
+  decor "#pragma HLS loop_tripcount max=151 min=0"
+  let r:bit<32> = b_idx * 129;
+
+  if (ptr[r + a_idx] == ALIGN) {
+    alignedA[a_str_idx] := SEQA[a_idx-1];
+    alignedB[b_str_idx] := SEQB[b_idx-1];
+    a_idx := a_idx - 1;
+    b_idx := b_idx - 1;
+  } else {
+    if (ptr[r + a_idx] == SKIPB) {
+      alignedA[a_str_idx] := SEQA[a_idx-1];
+      alignedB[b_str_idx] := DASH;
+      a_idx := a_idx - 1;
+    } else {
+      alignedA[a_str_idx] := DASH;
+      alignedB[b_str_idx] := SEQB[b_idx-1];
+      b_idx := b_idx - 1;
+    }
+  }
+  a_str_idx := a_str_idx + 1;
+  b_str_idx := b_str_idx + 1;
+}
+---
+while (a_str_idx < 256) {
+  decor "#pragma HLS loop_tripcount max=105 min=0"
+  alignedA[a_str_idx] := UNDERSCORE;
+  a_str_idx := a_str_idx + 1;
+}
+
+while (b_str_idx < 256) {
+  decor "#pragma HLS loop_tripcount max=105 min=0"
+  alignedB[b_str_idx] := UNDERSCORE;
+  b_str_idx := b_str_idx + 1;
+}

--- a/machsuite/sort-merge.fuse
+++ b/machsuite/sort-merge.fuse
@@ -1,0 +1,75 @@
+def merge (a: bit<32>[2048], start: bit<16>, m: bit<16>, stop: bit<16>) = {
+   let temp: bit<32>[2048];
+    //let temp: float[2048];
+   {
+   let i: bit<16> = start;
+   let j: bit<16> = m+1;
+   ---
+   while (i<=m){
+     decor "#pragma HLS loop_tripcount avg=5"
+     temp[i] := a[i];
+     i := i+1;
+   }
+   ---
+   while (j<=stop){
+    decor "#pragma HLS loop_tripcount avg=6"
+    temp[m+1+stop-j] := a[j];
+    j := j+1;
+   }
+   ---
+   let k = start;
+   i := start;
+   j := stop;
+   ---
+   while (k <= stop) {
+    decor "#pragma HLS loop_tripcount avg=11"
+    let temp_j: bit<32>  = 0;
+    let temp_i: bit<32>  = 0;
+    {
+    temp_j := temp[j];
+    ---
+    temp_i  := temp[i];
+    ---
+     if(temp_j < temp_i) {
+       a[k] := temp_j;
+       j := j-1;
+     } else {
+       a[k] := temp_i;
+       i := i+1;
+     }
+     }
+  k := k+1
+  }
+  }
+}
+
+
+// sorting
+
+decl a: bit<32>[2048];
+let start: bit<16> = 0;
+let stop: bit<16> = 2048;
+let m: bit<16> = 1;
+let from: bit<16> = 0;
+let mid: bit<16> = 0;
+let to: bit<16> = 0;
+---
+while (m < stop - start) {
+  decor "#pragma HLS loop_tripcount avg=2047"
+  let i = start;
+  while (i < stop) {
+    decor "#pragma HLS loop_tripcount avg=186"
+    from := i;
+    mid := i+m-1;
+    to := i+m+m-1
+    ---
+    if(to < stop){
+     merge(a, from, mid, to);
+    }
+    else{
+     merge(a, from, mid, stop);
+    }
+    i := i+m+m
+   }
+ m := m+m
+}

--- a/machsuite/sort-radix.fuse
+++ b/machsuite/sort-radix.fuse
@@ -1,0 +1,213 @@
+// def local_scan(bucket: bit<32>[128][16]) {
+//   let bucket_tmp1: bit<32> = 0;
+//   let bucket_tmp2: bit<32> = 0;
+//   for (let radix_id = 0..128) {
+//     for (let i = 1..16) {
+//       bucket_tmp1 := bucket[radix_id][i - 1];
+//       ---
+//       bucket_tmp2 := bucket[radix_id][i];
+//       ---
+//       bucket[radix_id][i] := bucket_tmp1 + bucket_tmp2;
+//     }
+//   }
+// }
+
+// def sum_scan(sum: bit<32>[128], bucket: bit<32>[128][16]) {
+//   let sum_tmp: bit<32> = 0;
+//   sum[0] := 0;
+//   ---
+//   for (let radix_id = 0..127) {
+//     sum_tmp := sum[radix_id];
+//     ---
+//     sum[radix_id + 1] := sum_tmp + bucket[radix_id][15];
+//   }
+// }
+
+// def last_step_scan(bucket: bit<32>[128][16], sum: bit<32>[128]) {
+//   let bucket_tmp: bit<32> = 0;
+//   for (let radix_id = 0..128) {
+//     for (let i = 0..16) {
+//       bucket_tmp := bucket[radix_id][i];
+//       ---
+//       bucket[radix_id][i] := bucket_tmp + sum[radix_id];
+//     }
+//   }
+// }
+
+// def init(bucket: bit<32>[128][16]) {
+//   for (let i = 0..128) {
+//     for (let j = 0..16) {
+//       bucket[i][j] := 0;
+//     }
+//   }
+// }
+
+// def hist(bucket: bit<32>[128][16], a: bit<32>[512][4], exp: bit<32>) {
+//   let bucket_idx: bit<32> = 0;
+//   let bucket_tmp: bit<32> = 0;
+//   for (let block_id = 0..512) {
+//     for (let i = 0..4) {
+//       bucket_idx := ((a[block_id][i] >> exp) & 0x3) * 512 + block_id + 1;
+//       bucket_tmp := bucket[bucket_idx / 16][bucket_idx % 16];
+//       ---
+//       bucket[bucket_idx / 16][bucket_idx % 16] := bucket_tmp + 1;
+//     }
+//   }
+// }
+
+// def update(b: bit<32>[512][4], bucket: bit<32>[128][16], a: bit<32>[512][4], exp: bit<32>) {
+
+//   let bucket_idx: bit<32> = 0;
+//   let elem_per_block: bit<32> = 4;
+//   let a_idx: bit<32> = 0;
+
+//   let bucket_tmp: bit<32> = 0;
+
+//   for (let block_id = 0..512) {
+//     for (let i = 0..4) {
+//       bucket_idx := ((a[block_id][i] >> exp) & 0x3) * 512 + block_id;
+//       bucket_tmp := bucket[bucket_idx / 16][bucket_idx % 16];
+//       ---
+//       b[bucket_tmp / 4][bucket_tmp % 4] := a[block_id][i];
+//       bucket[bucket_idx / 16][bucket_idx % 16] := bucket_tmp + 1;
+//     }
+//   }
+// }
+
+decl a: bit<32>[512][4];
+decl b: bit<32>[512][4];
+decl bucket: bit<32>[128][16];
+decl sum: bit<32>[128];
+
+let valid_buffer = 0;
+let buffer_a = 0;
+let buffer_b = 1;
+let temp_valid_buffer = 0;
+
+for (let exp = 0..16) {
+  // inline
+  // init(bucket);
+  for (let i = 0..128) {
+    for (let j = 0..16) {
+      bucket[i][j] := 0;
+    }
+  }
+  // inline
+
+  ---
+  if (valid_buffer == buffer_a) {
+    // inline
+    // hist(bucket, a, exp << 1);
+    let bucket_idx: bit<32> = 0;
+    let bucket_tmp: bit<32> = 0;
+    for (let block_id = 0..512) {
+      for (let i = 0..4) {
+        bucket_idx := ((a[block_id][i] >> (exp << 1)) & 0x3) * 512 + block_id + 1;
+        bucket_tmp := bucket[bucket_idx / 16][bucket_idx % 16];
+        ---
+        bucket[bucket_idx / 16][bucket_idx % 16] := bucket_tmp + 1;
+      }
+    }
+    // inline
+  } else {
+    // inline
+    // hist(bucket, b, exp << 1);
+    let bucket_idx: bit<32> = 0;
+    let bucket_tmp: bit<32> = 0;
+    for (let block_id = 0..512) {
+      for (let i = 0..4) {
+        bucket_idx := ((b[block_id][i] >> (exp << 1)) & 0x3) * 512 + block_id + 1;
+        bucket_tmp := bucket[bucket_idx / 16][bucket_idx % 16];
+        ---
+        bucket[bucket_idx / 16][bucket_idx % 16] := bucket_tmp + 1;
+      }
+    }
+    // inline
+  }
+
+  ---
+  // inline
+  // local_scan(bucket);
+  let bucket_tmp1: bit<32> = 0;
+  let bucket_tmp2: bit<32> = 0;
+  for (let radix_id = 0..128) {
+    for (let i = 1..16) {
+      bucket_tmp1 := bucket[radix_id][i - 1];
+      ---
+      bucket_tmp2 := bucket[radix_id][i];
+      ---
+      bucket[radix_id][i] := bucket_tmp1 + bucket_tmp2;
+    }
+  }
+  // inline
+  ---
+  // inline
+  // sum_scan(sum, bucket);
+  let sum_tmp: bit<32> = 0;
+  sum[0] := 0;
+  ---
+  for (let radix_id = 0..127) {
+    sum_tmp := sum[radix_id];
+    ---
+    sum[radix_id + 1] := sum_tmp + bucket[radix_id][15];
+  }
+  // inline
+  ---
+  // inline
+  // last_step_scan(bucket, sum);
+  let bucket_tmp: bit<32> = 0;
+  for (let radix_id = 0..128) {
+    for (let i = 0..16) {
+      bucket_tmp := bucket[radix_id][i];
+      ---
+      bucket[radix_id][i] := bucket_tmp + sum[radix_id];
+    }
+  }
+  // inline
+
+  ---
+  if (valid_buffer == buffer_a) {
+    // inline
+    // update(b, bucket, a, exp << 1);
+    let bucket_idx: bit<32> = 0;
+    let elem_per_block: bit<32> = 4;
+    let a_idx: bit<32> = 0;
+
+    let bucket_tmp_10: bit<32> = 0;
+
+    for (let block_id = 0..512) {
+      for (let i = 0..4) {
+        bucket_idx := ((a[block_id][i] >> (exp << 1)) & 0x3) * 512 + block_id;
+        bucket_tmp_10 := bucket[bucket_idx / 16][bucket_idx % 16];
+        ---
+        b[bucket_tmp_10 / 4][bucket_tmp_10 % 4] := a[block_id][i];
+        bucket[bucket_idx / 16][bucket_idx % 16] := bucket_tmp_10 + 1;
+      }
+    }
+    // inline
+    temp_valid_buffer := buffer_b;
+  } else {
+    // inline
+    // update(a, bucket, b, exp << 1);
+    let bucket_idx: bit<32> = 0;
+    let elem_per_block: bit<32> = 4;
+    let a_idx: bit<32> = 0;
+
+    let bucket_tmp_11: bit<32> = 0;
+
+    for (let block_id = 0..512) {
+      for (let i = 0..4) {
+        bucket_idx := ((b[block_id][i] >> (exp << 1)) & 0x3) * 512 + block_id;
+        bucket_tmp_11 := bucket[bucket_idx / 16][bucket_idx % 16];
+        ---
+        a[bucket_tmp_11 / 4][bucket_tmp_11 % 4] := b[block_id][i];
+        bucket[bucket_idx / 16][bucket_idx % 16] := bucket_tmp_11 + 1;
+      }
+    }
+    // inline
+    temp_valid_buffer := buffer_a;
+  }
+
+  ---
+  valid_buffer := temp_valid_buffer;
+}

--- a/machsuite/spmv-crs.fuse
+++ b/machsuite/spmv-crs.fuse
@@ -1,0 +1,30 @@
+decl val: fix<64, 32>[1666];
+decl cols: bit<32>[1666];
+decl row_delimiters: bit<32>[495];
+decl vec: fix<64, 32>[494];
+decl out: fix<64, 32>[494];
+
+let sum: fix<64, 32> = 0.0;
+let si: fix<64, 32> = 0.0;
+
+let tmp_begin: bit<32> = 0;
+let tmp_end: bit<32> = 0;
+let j: bit<32> = 0;
+
+for (let i: ubit<9> = 0..494) {
+  sum := (0.0 as fix<64, 32>);
+  si := (0.0 as fix<64, 32>);
+  tmp_begin := row_delimiters[i];
+  ---
+  tmp_end := row_delimiters[i+1];
+
+  j := tmp_begin;
+  while (j < tmp_end) {
+    decor "#pragma HLS loop_tripcount avg=3"
+    let c_idx = cols[j];
+    si := val[j] * vec[c_idx];
+    sum := sum + si;
+    j := j + 1;
+  }
+  out[i] := sum;
+}

--- a/machsuite/spmv-ellpack.fuse
+++ b/machsuite/spmv-ellpack.fuse
@@ -1,0 +1,12 @@
+decl nzval: double[494][10];
+decl cols: bit<32>[494][10];
+decl vec: double[494];
+decl out: double[494];
+
+for (let i = 0..494) {
+  for (let j = 0..10) {
+    let si = nzval[i][j] * vec[cols[i][j]];
+  } combine {
+    out[i] += si;
+  }
+}

--- a/machsuite/stencil-stencil2d.fuse
+++ b/machsuite/stencil-stencil2d.fuse
@@ -1,0 +1,20 @@
+decl orig: bit<32>[128][64];
+decl sol: bit<32>[128][64];
+decl filter: bit<32>[3][3];
+
+for (let r = 0..126) {
+  for (let c = 0..62) {
+    let temp: bit<32> = 0;
+    for (let k1 = 0..3) {
+      let temp_2: bit<32> = 0;
+      for (let k2 = 0..3) {
+        let mul = filter[k1][k2] * orig[r+k1][c+k2];
+      } combine {
+        temp_2 += mul;
+      }
+    } combine {
+      temp += temp_2;
+    }
+    sol[r][c] := temp;
+  }
+}

--- a/machsuite/stencil-stencil3d.fuse
+++ b/machsuite/stencil-stencil3d.fuse
@@ -1,0 +1,52 @@
+decl C: bit<32>[2];
+decl orig: bit<32>[32][32][16];
+decl sol: bit<32>[32][32][16];
+
+// Handle boundary conditions by filling with original values
+for (let j = 0..32) {
+  for (let k = 0..16) {
+    sol[0][j][k] := orig[0][j][k];
+    ---
+    sol[31][j][k] := orig[31][j][k];
+  }
+}
+---
+
+for (let i = 1..31) {
+  for (let k = 0..16) {
+    sol[i][0][k] := orig[i][0][k];
+    ---
+    sol[i][31][k] := orig[i][31][k];
+  }
+}
+---
+
+for (let i = 1..31) {
+  for (let j = 1..31) {
+    sol[i][j][0] := orig[i][j][0];
+    ---
+    sol[i][j][15] := orig[i][j][15];
+  }
+}
+---
+
+// Stencil computation
+for (let i = 1..31) {
+  for (let j = 1..31) {
+    for (let k = 1..15) {
+      let temp1 = orig[i][j][k] * C[0];
+      ---
+      let temp2 = orig[i + 1][j][k] * C[1] + temp1;
+      ---
+      let temp3 = orig[i - 1][j][k] * C[1] + temp2;
+      ---
+      let temp4 = orig[i][j + 1][k] * C[1] + temp3;
+      ---
+      let temp5 = orig[i][j - 1][k] * C[1] + temp4;
+      ---
+      let temp6 = orig[i][j][k + 1] * C[1] + temp5;
+      ---
+      sol[i][j][k] := orig[i][j][k - 1] * C[1] + temp6;
+    }
+  }
+}


### PR DESCRIPTION
Attempt to port all Machsuite benchmarks from the original Dahlia evaluation. Some benchmarks will not work because the Calyx backend does not support struct definitions yet.
