### PR TITLE
Bump runt.toml version to 0.4.1

### DIFF
--- a/benchmarks/runt.toml
+++ b/benchmarks/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.4.0"
+ver = "0.4.1"
 
 [[tests]]
 name = "Gold"


### PR DESCRIPTION
Will let [Calyx issue #1698](https://github.com/cucapra/calyx/pull/1698) pass (in theory).